### PR TITLE
add GHA for docker-compose.yaml check

### DIFF
--- a/.github/workflows/docker-compose-check.yaml
+++ b/.github/workflows/docker-compose-check.yaml
@@ -1,0 +1,18 @@
+name: Docker Compose Config Check
+
+on:
+ pull_request:
+    branches:
+      - main # Adjust this to your default branch if different
+
+jobs:
+ docker-compose-check:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Run Docker Compose Config
+      run: docker compose config
+


### PR DESCRIPTION
This enables a ruleset to protect main branch from certain errors in the docker-compose.yaml file.